### PR TITLE
Test with plone installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,4 +6,10 @@
 1.1.0 (unreleased)
 ==================
 
-- Initial PyPI release.
+- Initial PyPI release. This implements a subset of the ``plone.i18n``
+  APIs (not including flag resources) but with updated data and
+  reduced dependencies.
+
+- Python 3 and PyPy compatibility.
+
+- Data live in external files so that they are hopefully easier to update.

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -3,3 +3,4 @@ pip>=8.1.2
 setuptools>=23.0.0
 repoze.sphinx.autointerface
 sphinx_rtd_theme
+plone.i18n < 3.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=_read('README.rst'),
     url="https://github.com/NextThought/nti.i18n",
     license='Apache',
-    keywords='Site management',
+    keywords='i18n l10n zope component iana data locales',
     classifiers=[
         'Intended Audience :: Developers',
         'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,16 @@ setup(
     ],
     extras_require={
         'test': TESTS_REQUIRE,
+        'test:python_version == "2.7"': [
+            # Not ported to Py3 yet; Plus, version 3 adds hard dep on
+            # Products.CMFCore/Zope2 that we don't want. So long as we
+            # don't try to load its configuration, we can access its
+            # interfaces, though, on any version of Python. We just
+            # keep it here to avoid having to add 'pragma: no cover' to the
+            # conditional imports.
+            'plone.i18n < 3.0',
+            'zope.browserresource',  # Used by plone.i18n implicitly
+
+        ],
     },
 )

--- a/src/nti/i18n/locales/tests/__init__.py
+++ b/src/nti/i18n/locales/tests/__init__.py
@@ -1,1 +1,10 @@
 # Make a package
+
+import unittest
+
+def skipIfNoPlone(func):
+    try:
+        import plone.i18n
+        return func
+    except ImportError:
+        return unittest.skip("plone.i18n not available")(func)

--- a/src/nti/i18n/locales/tests/test_cctld.py
+++ b/src/nti/i18n/locales/tests/test_cctld.py
@@ -15,6 +15,8 @@ from zope import component
 import nti.i18n
 from nti.i18n.locales.interfaces import ICcTLDInformation
 
+from . import skipIfNoPlone
+
 try:
     unicode
 except NameError:
@@ -36,3 +38,10 @@ class TestConfiguredTLDUtility(unittest.TestCase):
 
         # Bad tlds
         self.assertRaises(KeyError, info.getLanguagesForTLD, __name__)
+
+    @skipIfNoPlone
+    def test_lookup_utility_with_plone_iface(self):
+        from plone.i18n.locales.interfaces import ICcTLDInformation as IPlone
+        from nti.i18n.locales.cctld import CcTLDInformation
+        utility = component.getUtility(IPlone)
+        self.assertIsInstance(utility, CcTLDInformation)

--- a/src/nti/i18n/locales/tests/test_countries.py
+++ b/src/nti/i18n/locales/tests/test_countries.py
@@ -15,6 +15,8 @@ from zope import component
 import nti.i18n.locales
 from nti.i18n.locales.interfaces import ICountryAvailability
 
+from . import skipIfNoPlone
+
 try:
     unicode
 except NameError:
@@ -33,3 +35,10 @@ class TestConfiguredCountryUtility(unittest.TestCase):
         self.assertIsInstance(
             availability.getCountries()[u'us'][u'name'],
             unicode)
+
+    @skipIfNoPlone
+    def test_lookup_utility_with_plone_iface(self):
+        from plone.i18n.locales.interfaces import ICountryAvailability as IPlone
+        from nti.i18n.locales.countries import CountryAvailability
+        utility = component.getUtility(IPlone)
+        self.assertIsInstance(utility, CountryAvailability)


### PR DESCRIPTION
Test that we can look up our utilities using the plone interfaces if they are installed. This actually works under both python2 and 3, we just can't configure under Python 3.